### PR TITLE
fix: format `create` DB response

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -19,6 +19,18 @@ export interface ApiDatabaseResponse extends Database {
   Hostname: string;
 }
 
+export interface ApiCreateDatabaseResponse {
+  DbId: string;
+  Hostname: string;
+  Name: string;
+}
+
+export interface DatabaseCreateResponse {
+  name: string;
+  id: string;
+  hostname: string;
+}
+
 export interface DatabaseInstanceUsageDetail {
   rows_read: number;
   rows_written: number;
@@ -85,7 +97,7 @@ export class DatabaseClient {
         timestamp?: string | Date;
       };
     }
-  ): Promise<Database> {
+  ): Promise<DatabaseCreateResponse> {
     if (options?.seed) {
       if (options.seed.type === "database" && !options.seed.name) {
         throw new Error("Seed name is required when type is 'database'");
@@ -100,7 +112,7 @@ export class DatabaseClient {
     }
 
     const response = await TursoClient.request<{
-      database: ApiDatabaseResponse;
+      database: ApiCreateDatabaseResponse;
     }>(`organizations/${this.config.org}/databases`, this.config, {
       method: "POST",
       headers: {
@@ -112,7 +124,7 @@ export class DatabaseClient {
       }),
     });
 
-    return this.formatResponse(response.database);
+    return this.formatCreateResponse(response.database);
   }
 
   async updateVersion(dbName: string): Promise<void> {
@@ -240,6 +252,16 @@ export class DatabaseClient {
       type: db.type,
       version: db.version,
       group: db.group,
+    };
+  }
+
+  private formatCreateResponse(
+    db: ApiCreateDatabaseResponse
+  ): DatabaseCreateResponse {
+    return {
+      id: db.DbId,
+      hostname: db.Hostname,
+      name: db.Name,
     };
   }
 }

--- a/src/database.ts
+++ b/src/database.ts
@@ -99,22 +99,20 @@ export class DatabaseClient {
       options.seed.timestamp = this.formatDateParameter(options.seed.timestamp);
     }
 
-    const response = await TursoClient.request<{ database: Database }>(
-      `organizations/${this.config.org}/databases`,
-      this.config,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          name: dbName,
-          ...options,
-        }),
-      }
-    );
+    const response = await TursoClient.request<{
+      database: ApiDatabaseResponse;
+    }>(`organizations/${this.config.org}/databases`, this.config, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        name: dbName,
+        ...options,
+      }),
+    });
 
-    return response.database;
+    return this.formatResponse(response.database);
   }
 
   async updateVersion(dbName: string): Promise<void> {

--- a/src/database.ts
+++ b/src/database.ts
@@ -13,11 +13,9 @@ export interface Database {
   group?: string;
 }
 
-export interface ApiDatabaseResponse extends Database {
-  Name: string;
-  DbId: string;
-  Hostname: string;
-}
+export interface ApiDatabaseResponse
+  extends Database,
+    ApiCreateDatabaseResponse {}
 
 export interface ApiCreateDatabaseResponse {
   DbId: string;
@@ -88,7 +86,7 @@ export class DatabaseClient {
   async create(
     dbName: string,
     options?: {
-      image: "latest" | "canary";
+      image?: "latest" | "canary";
       group?: string;
       seed?: {
         type: "database" | "dump";


### PR DESCRIPTION
Currently, the return value of `turso.databases.create()` includes PascalCase keys, which doesn't match the types for the method.

This is the current response when creating a new DB.

```
{
    DbId: <database-id>,
    Hostname: <hostname>,
    IssuedCertCount: 0,
    IssuedCertLimit: 0,
    Name: <name>
} 
```

This is what TS thinks is returned.
<img width="540" alt="Screenshot 2024-01-22 at 16 19 29" src="https://github.com/tursodatabase/turso-api-client-ts/assets/55989505/a159c913-5a1d-4d1d-81ce-d58656a31f04">

The changes I made will only convert keys to snakeCase, but the types are still incorrect. Eg. version is not returned but TS thinks it is. 

**More than happy to make further changes, as this is just a quick patch really.** 