### PR TITLE
Use API error messages when throwing errors, whenever possible.

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TursoClient, createClient } from "./client";
+import { TursoClient, TursoClientError, createClient } from "./client";
 
 describe("TursoClient", () => {
   it("should throw an error if no API token is provided", () => {
@@ -16,6 +16,23 @@ describe("TursoClient", () => {
     const client = new TursoClient(config);
 
     expect(client).toBeInstanceOf(TursoClient);
+  });
+
+  it("should throw an error message that will match with API's error message", async () => {
+    const config = { org: "turso", token: "abc" };
+    const client = new TursoClient(config);
+
+    const error = await client.databases
+      .get("databaseName")
+      .catch((err: Error) => err);
+
+    expect(error).toBeInstanceOf(TursoClientError);
+    if (error instanceof TursoClientError) {
+      expect(error.message).toBe(
+        "token contains an invalid number of segments"
+      );
+      expect(error.status).toBe(401);
+    }
   });
 });
 


### PR DESCRIPTION
Hi, on your rest API documentation, it has defined error messages. but currently all thrown error message are `Something went wrong` + Http status code.

```typescript
if (!response.ok) {
    throw new Error(`Something went wrong! Status ${response.status}`);
}
```

This change assumes that all known API error response will return 
``` json
{
  "error": "message"
}
```
and throw a custom error including http status code and will only throw  `Something went wrong`  error message when error response is not json.
