### PR TITLE
feat: list invoices and deleteInvite

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ const orgMembers = await turso.organizations.delete();
 const orgMembers = await turso.organizations.members();
 const orgMembers = await turso.organizations.addMember("username", "admin");
 const orgMembers = await turso.organizations.removeMember("username");
-const orgMembers = await turso.organizations.inviteUser(
+const invite = await turso.organizations.inviteUser(
   "jamie@turso.tech",
   "admin"
 );
+await turso.organizations.deleteInvite("jamie@turso.tech");
 const invoices = await turso.organizations.invoices();
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ const orgMembers = await turso.organizations.inviteUser(
   "jamie@turso.tech",
   "admin"
 );
+const invoices = await turso.organizations.invoices();
 ```
 
 ```ts
@@ -80,6 +81,12 @@ const database = await turso.databases.create("db-name", {
     name: "my-existing-db",
     timestamp: "2021-01-01T00:00:00Z", // or new Date("2021-01-01T00:00:00Z")
   },
+});
+const database = await turso.databases.create("parent-db", {
+  is_schema: true,
+});
+const database = await turso.databases.create("child-db", {
+  schema: "parent-db",
 });
 
 const database = await turso.databases.updateVersion("my-db");

--- a/src/organization.ts
+++ b/src/organization.ts
@@ -28,6 +28,15 @@ export interface OrganizationInvite {
   Accepted: boolean;
 }
 
+export interface Invoice {
+  invoice_number: string;
+  amount_due: string;
+  due_date: string;
+  paid_at: string;
+  payment_failed_at: string;
+  invoice_pdf: string;
+}
+
 export class OrganizationClient {
   constructor(private config: TursoConfig) {}
 
@@ -42,8 +51,8 @@ export class OrganizationClient {
   async update(options: { overages: boolean }): Promise<Organization> {
     const response = await TursoClient.request<{
       organization: Organization;
-    }>("", this.config, {
-      method: "POST",
+    }>(`organizations/${this.config.org}`, this.config, {
+      method: "PATCH",
       body: JSON.stringify(options),
     });
 
@@ -51,15 +60,19 @@ export class OrganizationClient {
   }
 
   async delete(): Promise<void> {
-    return TursoClient.request("", this.config, {
-      method: "DELETE",
-    });
+    return TursoClient.request(
+      `organizations/${this.config.org}`,
+      this.config,
+      {
+        method: "DELETE",
+      }
+    );
   }
 
   async members(): Promise<OrganizationMember[]> {
     const response = await TursoClient.request<{
       members: OrganizationMember[];
-    }>(`organisations/${this.config.org}/members`, this.config);
+    }>(`organizations/${this.config.org}/members`, this.config);
 
     return response.members ?? [];
   }
@@ -68,16 +81,27 @@ export class OrganizationClient {
     username: string,
     role?: "admin" | "member"
   ): Promise<{ member: string; role: "admin" | "member" }> {
-    return TursoClient.request(`members/${username}`, this.config, {
-      method: "POST",
-      body: JSON.stringify({ member: username, role: role ? role : "member" }),
-    });
+    return TursoClient.request(
+      `organizations/${this.config.org}/members/${username}`,
+      this.config,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          member: username,
+          role: role ? role : "member",
+        }),
+      }
+    );
   }
 
   async removeMember(username: string): Promise<{ member: string }> {
-    return TursoClient.request(`members/${username}`, this.config, {
-      method: "DELETE",
-    });
+    return TursoClient.request(
+      `organizations/${this.config.org}/members/${username}`,
+      this.config,
+      {
+        method: "DELETE",
+      }
+    );
   }
 
   async inviteUser(
@@ -85,7 +109,7 @@ export class OrganizationClient {
     role?: "admin" | "member"
   ): Promise<OrganizationInvite> {
     const response = await TursoClient.request<{ invited: OrganizationInvite }>(
-      "invites",
+      `organizations/${this.config.org}/invites`,
       this.config,
       {
         method: "POST",
@@ -94,5 +118,23 @@ export class OrganizationClient {
     );
 
     return response.invited;
+  }
+
+  async deleteInvite(email: string): Promise<OrganizationInvite> {
+    return TursoClient.request(
+      `organizations/${this.config.org}/invites/${email}`,
+      this.config,
+      {
+        method: "DELETE",
+      }
+    );
+  }
+
+  async invoices(): Promise<Invoice[]> {
+    const response = await TursoClient.request<{
+      invoices: Invoice[];
+    }>(`organizations/${this.config.org}/invoices`, this.config);
+
+    return response.invoices ?? [];
   }
 }


### PR DESCRIPTION
- Adds `invoices()` method to return org invoices
- Adds `deleteInvite(email)` method to delete user invites
- Fixes the paths for organization to use the URL instead of the header
