### PR TITLE
fix: export TursoClientError as value, not just type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import "whatwg-fetch";
 
-export { createClient } from "./client";
+export { createClient, TursoClientError } from "./client";
 
 export type {
   ApiToken,
@@ -8,7 +8,6 @@ export type {
   RevokedApiToken,
   ApiTokenValidation,
 } from "./api-token";
-export type { TursoClientError } from "./client";
 export type { TursoConfig } from "./config";
 export type {
   Database,


### PR DESCRIPTION
TursoClientError was exported with 'export type' which only exports the TypeScript type, not the runtime class. This prevents users from using 'instanceof TursoClientError' to catch and handle API errors.

Changed to a regular export so the class is available at runtime.