### PR TITLE
Migrate invite methods to v2 API endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tursodatabase/api",
   "description": "The Turso API gives you everything needed to manage your organization and it's members, groups, databases, and API tokens.",
-  "version": "1.9.2",
+  "version": "2.0.0",
   "license": "MIT",
   "repository": "tursodatabase/turso-api-client-ts",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export type {
   Organization,
   OrganizationMember,
   OrganizationInvite,
+  OrganizationInviteCreated,
   Invoice,
   OrganizationMemberRole,
   OrganizationAddedMember,

--- a/src/organization.ts
+++ b/src/organization.ts
@@ -17,15 +17,18 @@ export interface OrganizationMember {
 }
 
 export interface OrganizationInvite {
-  ID: number;
-  CreatedAt: string;
-  UpdatedAt: string;
-  DeletedAt: string;
-  Role: "admin" | "member";
-  Email: string;
-  OrganizationID: number;
-  Organization: Organization;
-  Accepted: boolean;
+  id: number;
+  email: string;
+  role: "admin" | "member" | "viewer";
+  token: string;
+  created_at: string;
+}
+
+export interface OrganizationInviteCreated {
+  email: string;
+  role: "admin" | "member" | "viewer";
+  organization: string;
+  token: string;
 }
 
 export interface Invoice {
@@ -115,12 +118,25 @@ export class OrganizationClient {
     );
   }
 
+  async listInvites(): Promise<OrganizationInvite[]> {
+    const response = await TursoClient.request<{
+      invites: OrganizationInvite[];
+    }>(
+      `../v2/organizations/${this.config.org}/invites`,
+      this.config
+    );
+
+    return response.invites ?? [];
+  }
+
   async inviteUser(
     email: string,
     role?: OrganizationMemberRole
-  ): Promise<OrganizationInvite> {
-    const response = await TursoClient.request<{ invited: OrganizationInvite }>(
-      `organizations/${this.config.org}/invites`,
+  ): Promise<OrganizationInviteCreated> {
+    const response = await TursoClient.request<{
+      invited: OrganizationInviteCreated;
+    }>(
+      `../v2/organizations/${this.config.org}/invites`,
       this.config,
       {
         method: "POST",
@@ -131,9 +147,9 @@ export class OrganizationClient {
     return response.invited;
   }
 
-  async deleteInvite(email: string): Promise<OrganizationInvite> {
-    return TursoClient.request(
-      `organizations/${this.config.org}/invites/${email}`,
+  async deleteInvite(email: string): Promise<void> {
+    await TursoClient.request(
+      `../v2/organizations/${this.config.org}/invites/${email}`,
       this.config,
       {
         method: "DELETE",


### PR DESCRIPTION
BREAKING CHANGE: OrganizationInvite type now uses lowercase keys (id, email, role, token, created_at) matching the v2 API response. The old v1 shape with uppercase keys and nested Organization object is removed. deleteInvite now returns void instead of OrganizationInvite.

New method: listInvites() for listing pending organization invites.
New type: OrganizationInviteCreated for the inviteUser response.

Bump to 2.0.0.