### PR TITLE
Add support for provisioning databases with encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ const database = await turso.databases.create("parent-db", {
 const database = await turso.databases.create("child-db", {
   schema: "parent-db",
 });
+const database = await turso.databases.create("encrypted-db", {
+  group: "my-group",
+  remote_encryption: {
+    encryption_key: "<base64-encoded-key>",
+    encryption_cipher: "aes256gcm",
+  },
+});
 
 const database = await turso.databases.delete("my-db");
 

--- a/src/database.test.ts
+++ b/src/database.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { DatabaseClient } from "./database";
+import { TursoClient } from "./client";
 
 vi.mock("./client", () => ({
   TursoClient: { request: vi.fn() },
@@ -36,6 +37,36 @@ describe("DatabaseClient", () => {
     // @ts-expect-error
     await expect(client.create("testDB", options)).rejects.toThrow(
       "Seed URL is required when type is 'dump'"
+    );
+  });
+
+  it("forwards remote_encryption options when creating an encrypted database", async () => {
+    vi.mocked(TursoClient.request).mockResolvedValue({
+      database: { DbId: "id", Hostname: "host", Name: "testDB" },
+    });
+
+    await client.create("testDB", {
+      group: "default",
+      remote_encryption: {
+        encryption_key: "c29tZS1iYXNlNjQta2V5",
+        encryption_cipher: "aes256gcm",
+      },
+    });
+
+    expect(TursoClient.request).toHaveBeenCalledWith(
+      "organizations/turso/databases",
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          name: "testDB",
+          group: "default",
+          remote_encryption: {
+            encryption_key: "c29tZS1iYXNlNjQta2V5",
+            encryption_cipher: "aes256gcm",
+          },
+        }),
+      })
     );
   });
 });

--- a/src/database.ts
+++ b/src/database.ts
@@ -79,6 +79,27 @@ export interface DatabaseToken {
   jwt: string;
 }
 
+export type EncryptionCipher =
+  | "aes256gcm"
+  | "aes128gcm"
+  | "chacha20poly1305"
+  | "aegis128l"
+  | "aegis128x2"
+  | "aegis128x4"
+  | "aegis256"
+  | "aegis256x2"
+  | "aegis256x4";
+
+export interface RemoteEncryption {
+  /**
+   * Base64-encoded encryption key. Key size depends on the cipher: 32 bytes
+   * for aes256gcm, chacha20poly1305 and aegis256 variants; 16 bytes for
+   * aes128gcm and aegis128l variants.
+   */
+  encryption_key: string;
+  encryption_cipher: EncryptionCipher;
+}
+
 type MultiDBSchemaOptions =
   | { is_schema: boolean; schema?: never }
   | { is_schema?: never; schema: string }
@@ -142,6 +163,8 @@ export class DatabaseClient {
         url?: string;
         timestamp?: string | Date;
       };
+      size_limit?: string;
+      remote_encryption?: RemoteEncryption;
     } & MultiDBSchemaOptions
   ): Promise<CreatedDatabase> {
     if (hasIsSchemaOption(options) && hasSchemaOption(options)) {


### PR DESCRIPTION
Add remote_encryption (and size_limit) options to databases.create, allowing creation of encrypted databases via the encryption_key and encryption_cipher fields documented in the create database API.