### PR TITLE
add database type

### DIFF
--- a/src/database.test.ts
+++ b/src/database.test.ts
@@ -40,6 +40,22 @@ describe("DatabaseClient", () => {
     );
   });
 
+  it("parses and propagates database_type from the get response", async () => {
+    vi.mocked(TursoClient.request).mockResolvedValue({
+      database: {
+        Name: "testDB",
+        DbId: "id",
+        Hostname: "host",
+        type: "logical",
+        database_type: "tursodb",
+      },
+    });
+
+    const database = await client.get("testDB");
+
+    expect(database.database_type).toBe("tursodb");
+  });
+
   it("forwards remote_encryption options when creating an encrypted database", async () => {
     vi.mocked(TursoClient.request).mockResolvedValue({
       database: { DbId: "id", Hostname: "host", Name: "testDB" },

--- a/src/database.ts
+++ b/src/database.ts
@@ -2,6 +2,12 @@ import { LocationKeys } from "./location";
 import { TursoConfig, resolveOrganization } from "./config";
 import { TursoClient } from "./client";
 
+/**
+ * The underlying database engine. `libsql` is the legacy engine; `tursodb` is
+ * provisioned when a database is created with the `useTursoDb` option.
+ */
+export type DatabaseType = "libsql" | "tursodb";
+
 export interface Database {
   name: string;
   id: string;
@@ -9,6 +15,7 @@ export interface Database {
   regions?: Array<keyof LocationKeys>;
   primaryRegion?: keyof LocationKeys;
   type: string;
+  database_type: DatabaseType;
   version: string;
   group?: string;
   sleeping: boolean;
@@ -356,6 +363,7 @@ export class DatabaseClient {
       regions: db.regions,
       primaryRegion: db.primaryRegion,
       type: db.type,
+      database_type: db.database_type,
       version: db.version,
       group: db.group,
       sleeping: db.sleeping,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type { TursoClientError } from "./client";
 export type { TursoConfig, TursoToken } from "./config";
 export type {
   Database,
+  DatabaseType,
   CreatedDatabase,
   DatabaseUsage,
   InstanceUsages,


### PR DESCRIPTION
Parse `database_type` field from the API response and propagate it to the SDK