### PR TITLE
docs: deprecate permissions option instead of whole createToken method

### DIFF
--- a/src/group.ts
+++ b/src/group.ts
@@ -128,13 +128,16 @@ export class GroupClient {
    * @param options Token creation options
    * @param options.expiration Token expiration
    * @param options.authorization Token authorization level
-   * @param options.permissions - @deprecated This parameter is deprecated and will be removed in a future version
+   * @param options.permissions This parameter is deprecated and will be removed in a future version
    */
   async createToken(
     groupName: string,
     options?: {
       expiration?: string;
       authorization?: "read-only" | "full-access";
+      /**
+       * @deprecated This parameter is deprecated and will be removed in a future version
+       */
       permissions?: {
         read_attach: { databases: Database["name"][] };
       };


### PR DESCRIPTION
Fixes the JSDoc deprecation annotation for `createToken`.

Currently, the `@deprecated` tag is placed in the method's JSDoc comment as part of the `@param` documentation. TypeScript interprets this as the entire `createToken` method being deprecated, causing editors to show deprecation warnings for every usage of the method.

This change moves the deprecation annotation to the `permissions` property itself so that only `options.permissions` is marked as deprecated.

I am aware of the current TypeScript limitation where deprecated object properties are not rendered with a strikethrough in some editor contexts. However, I believe that behavior is still less misleading than marking the entire `createToken` method as deprecated.